### PR TITLE
Endpoint -> Endpoints in readme?

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ let MySite =
                 Body =
                     [
                         H1 [Text "Hello world!"]
-                        "About" => Endpoint.About
+                        "About" => Endpoints.About
                     ]
             )
         | Endpoints.About ->
@@ -70,7 +70,7 @@ let MySite =
                 Body =
                     [
                         P [Text "This is a simple app"]
-                        "Home" => Endpoint.Home
+                        "Home" => Endpoints.Home
                     ]
             )
     )


### PR DESCRIPTION
In "Multi-page applications" example, should "Endpoint.About" and "Endpoint.Home" be replaced with "Endpoints.About" and "Endpoints.Home" accordingly?
